### PR TITLE
LIBFCREPO-1570. Code review.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,7 @@ FROM python:3.12.6-slim
 EXPOSE 5000
 
 ENV FLASK_DEBUG=0
-ENV SOLRIZER_FCREPO_JWT_SECRET={get secret from kubernetes}
-ENV SOLRIZER_FCREPO_ENDPOINT=https://fcrepo-test.lib.umd.edu/fcrepo/rest
 ENV SOLRIZER_IIIF_IDENTIFIER_PREFIX=fcrepo:
-ENV SOLRIZER_IIIF_MANIFESTS_URL_PATTERN=https://iiif-test.lib.umd.edu/manifests/{+id}/manifest.json
-ENV SOLRIZER_IIIF_THUMBNAIL_URL_PATTERN=https://iiif-test.lib.umd.edu/images/iiif/2/{+id}/full/250,/0/default.jpg
 ENV SOLRIZER_INDEXERS=content_model,discoverability,page_sequence,iiif_links,dates,facets
 
 WORKDIR /opt/solrizer

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ pdoc -p 8888 solrizer
 
 Now the documentation will be at <http://localhost:8888/>.
 
+### Docker Image
+
+Build the image:
+
+```zsh
+docker build -t docker.lib.umd.edu/solrizer .
+```
+
+Run, using the `.env` file set up earlier:
+
+```zsh
+docker run --rm -it -p 5000:5000 --env-file .env docker.lib.umd.edu/solrizer
+```
+
 ## License
 
 See the [LICENSE](LICENSE.md) file for license rights and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "python-dotenv",
     "python-iso639",
     "python-jsonpath",
+    # require rdflib 7.0.0+ in order to have access
+    # to the NamespaceManager.curie() method
+    "rdflib>=7.0.0",
     "requests-jwtauth",
     "uritemplate",
     "waitress",

--- a/src/solrizer/server.py
+++ b/src/solrizer/server.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 from waitress import serve
 
 from solrizer import __version__
-from solrizer.web import app
+from solrizer.web import create_app
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ def run(listen):
     logger.info(f'Starting {server_identity}')
     try:
         serve(
-            app=app(),
+            app=create_app(),
             listen=listen,
             ident=server_identity,
         )

--- a/src/solrizer/web.py
+++ b/src/solrizer/web.py
@@ -15,9 +15,6 @@ from solrizer.errors import (
 from solrizer.indexers import IndexerContext, IndexerError
 
 
-def app() -> Flask:
-    return create_app()
-
 def create_app():
     app = Flask(__name__)
     app.config.from_prefixed_env('SOLRIZER')


### PR DESCRIPTION
- removed redundant `app()` function from the `solrizer.web` module; the server module can just call `create_app()` itself
- require rdflib >= 7.0.0 to allow for using the `NamespaceManager.curie()` method
- removed some hardcoded values from the Dockerfile
- added instructions for building and running the Docker image to the README, including using the `.env` file to pass environment variables to the container

https://umd-dit.atlassian.net/browse/LIBFCREPO-1570